### PR TITLE
fix "Slate" theme referencing wrong css file

### DIFF
--- a/Slate/Slate.theme.css
+++ b/Slate/Slate.theme.css
@@ -41,7 +41,7 @@
 ====================================================================================
 */
 
-@import url("https://gibbu.github.io/BetterDiscord-Themes/AdjustableServerWidth/base.css");
+@import url("https://gibbu.github.io/BetterDiscord-Themes/Slate/base.css");
 
 /*
 ====================================================================================


### PR DESCRIPTION
Slate theme references the "AdjustableServerWidth" css file, instead of the "Slate" css, causing the Theme to cease working.